### PR TITLE
[Feature] Templating Services

### DIFF
--- a/app/Constants/SharedConstant.php
+++ b/app/Constants/SharedConstant.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Constants;
+
+/**
+ * SharedConstant can be used for any particular logic, no constraint or domain required
+ *
+ * Eg: a simple generic error message, key,...
+ */
+final class SharedConstant
+{
+    public const RENDER_ERROR_MSG = 'Failed to render HTML. Error: %s';
+}

--- a/app/Enums/TemplatingMode.php
+++ b/app/Enums/TemplatingMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum TemplatingMode: string
+{
+    case BLADE = 'blade';
+    case MARKDOWN = 'markdown';
+}

--- a/app/Http/Controllers/DocumentTemplateController.php
+++ b/app/Http/Controllers/DocumentTemplateController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\DocumentTemplateStoreRequest;
 use App\Http\Requests\DocumentTemplateUpdateRequest;
 use App\Http\Resources\DocumentTemplateResource;
 use App\Models\DocumentTemplate;
+use App\Services\TemplatingRenderManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Event;
 use stdClass;
@@ -84,9 +85,12 @@ class DocumentTemplateController extends Controller
         ]);
     }
 
-    public function previewHtml(DocumentTemplate $documentTemplate): JsonResponse
-    {
-        $html = $documentTemplate->renderHtml();
+    public function previewHtml(
+        DocumentTemplate $documentTemplate,
+        TemplatingRenderManager $manager
+    ): JsonResponse {
+        $html = $manager->setMode($documentTemplate->getTemplatingMode())
+            ->renderHtml($documentTemplate, $documentTemplate->default_variables);
 
         return new JsonResponse([
             'html' => $html,

--- a/app/Models/DocumentTemplate.php
+++ b/app/Models/DocumentTemplate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\TemplatingMode;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -40,18 +41,11 @@ class DocumentTemplate extends Model
         return $this->hasMany(DocumentFile::class, 'document_template_uuid');
     }
 
-    public function renderHtml(?array $variables = null): string
+    public function getTemplatingMode(): TemplatingMode
     {
-        $variables ??= $this->default_variables;
+        $rawMode = ($this->metadata['templating'] ?? null)
+            ?: TemplatingMode::BLADE->value;
 
-        return rescue(
-            fn () => Blade::render(
-                $this->template,
-                $variables,
-                deleteCachedView: true
-            ),
-            fn (Throwable $error)
-                => 'Failed to render HTML. Error: ' . Str::before($error->getMessage(), '(View:')
-        );
+        return TemplatingMode::from($rawMode);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Services\PdfRenderers\PdfRendererContract;
 use App\Services\PdfRenderManager;
+use App\Services\TemplatingServices\BladeTemplatingService;
+use App\Services\TemplatingServices\MarkdownTemplatingService;
 use Illuminate\Support\ServiceProvider;
 use App\Services\PdfRenderers\GotenbergRendererService;
 use App\Services\PdfRenderers\MpdfRendererService;
@@ -34,5 +36,13 @@ class AppServiceProvider extends ServiceProvider
         );
 
         $this->app->bind('mpdf-testing', Mpdf::class);
+
+        $this->bindTemplatingServices();
+    }
+
+    private function bindTemplatingServices(): void
+    {
+        $this->app->singleton(BladeTemplatingService::class);
+        $this->app->singleton(MarkdownTemplatingService::class);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace App\Providers;
 
+use App\Enums\TemplatingMode;
 use App\Services\PdfRenderers\PdfRendererContract;
 use App\Services\PdfRenderManager;
 use App\Services\TemplatingServices\BladeTemplatingService;
 use App\Services\TemplatingServices\MarkdownTemplatingService;
+use App\Services\TemplatingServices\TemplatingServiceContract;
 use Illuminate\Support\ServiceProvider;
 use App\Services\PdfRenderers\GotenbergRendererService;
 use App\Services\PdfRenderers\MpdfRendererService;

--- a/app/Services/PdfRenderers/AbstractPdfRendererService.php
+++ b/app/Services/PdfRenderers/AbstractPdfRendererService.php
@@ -4,6 +4,7 @@ namespace App\Services\PdfRenderers;
 
 use App\Models\DocumentFile;
 use App\Models\DocumentTemplate;
+use App\Services\TemplatingRenderManager;
 use Illuminate\Http\File;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Http;
@@ -24,7 +25,9 @@ abstract class AbstractPdfRendererService
         $inputFile = tempnam(sys_get_temp_dir(), 'rendered_html_template');
         rename($inputFile, $inputFile .= '.html');
 
-        $htmlRendered = Blade::render($template->template, $variables, deleteCachedView: true);
+        $htmlRendered = app(TemplatingRenderManager::class)
+            ->setMode($template->getTemplatingMode())
+            ->renderHtml($template, $variables);
 
         file_put_contents($inputFile, $htmlRendered);
 

--- a/app/Services/TemplatingRenderManager.php
+++ b/app/Services/TemplatingRenderManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TemplatingMode;
+use App\Models\DocumentTemplate;
+use App\Services\TemplatingServices\BladeTemplatingService;
+use App\Services\TemplatingServices\MarkdownTemplatingService;
+use App\Services\TemplatingServices\TemplatingServiceContract;
+
+class TemplatingRenderManager
+{
+    protected TemplatingMode $mode;
+
+    public function setMode(TemplatingMode $mode): self
+    {
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    public function renderHtml(DocumentTemplate $template, array $variables): string
+    {
+        /** @var TemplatingServiceContract $instance */
+        $instance = match ($this->mode) {
+            TemplatingMode::BLADE => app(BladeTemplatingService::class),
+            TemplatingMode::MARKDOWN => app(MarkdownTemplatingService::class),
+        };
+
+        return $instance->renderHtml($template, $variables);
+    }
+}

--- a/app/Services/TemplatingServices/BladeTemplatingService.php
+++ b/app/Services/TemplatingServices/BladeTemplatingService.php
@@ -3,12 +3,20 @@
 namespace App\Services\TemplatingServices;
 
 use App\Models\DocumentTemplate;
+use App\Utils\TemplatingErrorMessage;
 use Illuminate\Support\Facades\Blade;
 
 class BladeTemplatingService implements TemplatingServiceContract
 {
     public function renderHtml(DocumentTemplate $template, array $variables): string
     {
-        return Blade::render($template->template, $variables, deleteCachedView: true);
+        return rescue(
+            fn () => Blade::render(
+                $template->template,
+                $variables,
+                deleteCachedView: true
+            ),
+            TemplatingErrorMessage::resolveThrowable(...)
+        );
     }
 }

--- a/app/Services/TemplatingServices/BladeTemplatingService.php
+++ b/app/Services/TemplatingServices/BladeTemplatingService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\TemplatingServices;
+
+use App\Models\DocumentTemplate;
+use Illuminate\Support\Facades\Blade;
+
+class BladeTemplatingService implements TemplatingServiceContract
+{
+    public function renderHtml(DocumentTemplate $template, array $variables): string
+    {
+        return Blade::render($template->template, $variables, deleteCachedView: true);
+    }
+}

--- a/app/Services/TemplatingServices/MarkdownTemplatingService.php
+++ b/app/Services/TemplatingServices/MarkdownTemplatingService.php
@@ -21,10 +21,10 @@ class MarkdownTemplatingService implements TemplatingServiceContract
      */
     public function renderHtml(DocumentTemplate $template, array $variables): string
     {
-        $renderedMarkdown = $this->bladeTemplatingService->renderHtml($template, $variables);
+        $renderedHtml = $this->bladeTemplatingService->renderHtml($template, $variables);
 
         return rescue(
-            fn () => Markdown::parse($renderedMarkdown)->toHtml(),
+            fn () => Markdown::parse($renderedHtml)->toHtml(),
             TemplatingErrorMessage::resolveThrowable(...)
         );
     }

--- a/app/Services/TemplatingServices/MarkdownTemplatingService.php
+++ b/app/Services/TemplatingServices/MarkdownTemplatingService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services\TemplatingServices;
+
+use App\Models\DocumentTemplate;
+use Illuminate\Mail\Markdown;
+
+class MarkdownTemplatingService implements TemplatingServiceContract
+{
+    public function __construct(private BladeTemplatingService $bladeTemplatingService)
+    {
+    }
+
+    /**
+     * Before passing things to markdown stage, we need to resolve the template & variables
+     * using the normal Blade render
+     *
+     * After we got the rendered text, pass it to Markdown.
+     */
+    public function renderHtml(DocumentTemplate $template, array $variables): string
+    {
+        $renderedMarkdown = $this->bladeTemplatingService->renderHtml($template, $variables);
+
+        return Markdown::parse($renderedMarkdown)->toHtml();
+    }
+}

--- a/app/Services/TemplatingServices/MarkdownTemplatingService.php
+++ b/app/Services/TemplatingServices/MarkdownTemplatingService.php
@@ -3,12 +3,14 @@
 namespace App\Services\TemplatingServices;
 
 use App\Models\DocumentTemplate;
+use App\Utils\TemplatingErrorMessage;
 use Illuminate\Mail\Markdown;
 
 class MarkdownTemplatingService implements TemplatingServiceContract
 {
-    public function __construct(private BladeTemplatingService $bladeTemplatingService)
-    {
+    public function __construct(
+        private readonly BladeTemplatingService $bladeTemplatingService
+    ) {
     }
 
     /**
@@ -21,6 +23,9 @@ class MarkdownTemplatingService implements TemplatingServiceContract
     {
         $renderedMarkdown = $this->bladeTemplatingService->renderHtml($template, $variables);
 
-        return Markdown::parse($renderedMarkdown)->toHtml();
+        return rescue(
+            fn () => Markdown::parse($renderedMarkdown)->toHtml(),
+            TemplatingErrorMessage::resolveThrowable(...)
+        );
     }
 }

--- a/app/Services/TemplatingServices/TemplatingServiceContract.php
+++ b/app/Services/TemplatingServices/TemplatingServiceContract.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Services\TemplatingServices;
+
+use App\Models\DocumentTemplate;
+
+interface TemplatingServiceContract
+{
+    /**
+     * The contractor must be able to render the HTML with given template & variables
+     */
+    public function renderHtml(DocumentTemplate $template, array $variables): string;
+}

--- a/app/Utils/TemplatingErrorMessage.php
+++ b/app/Utils/TemplatingErrorMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Utils;
+
+use App\Constants\SharedConstant;
+use Illuminate\Support\Str;
+use Throwable;
+
+class TemplatingErrorMessage
+{
+    public static function resolveThrowable(Throwable $throwable): string
+    {
+        return sprintf(
+            SharedConstant::RENDER_ERROR_MSG,
+            Str::before($throwable->getMessage(), '(View:')
+        );
+    }
+}

--- a/tests/Integration/PdfRenderIntegrationTest.php
+++ b/tests/Integration/PdfRenderIntegrationTest.php
@@ -115,8 +115,8 @@ class PdfRenderIntegrationTest extends TestCase
             ],
         ]);
 
-        $response = $this->json('POST', 'api/v1/document-templates/' . $markdownTemplate->template->uuid . '/pdfs', [
-            'variables' => $markdownTemplate->template->default_variables,
+        $response = $this->json('POST', 'api/v1/document-templates/' . $markdownTemplate->uuid . '/pdfs', [
+            'variables' => $markdownTemplate->default_variables,
             'metadata' => [
                 'driver' => PdfService::GOTENBERG->value,
                 'templating' => TemplatingMode::MARKDOWN->value,

--- a/tests/Integration/PdfRenderIntegrationTest.php
+++ b/tests/Integration/PdfRenderIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration;
 
 use App\Enums\PdfService;
+use App\Enums\TemplatingMode;
 use App\Models\DocumentTemplate;
 use Smalot\PdfParser\Parser;
 use Tests\TestCase;
@@ -103,6 +104,38 @@ class PdfRenderIntegrationTest extends TestCase
         $this->assertStringContainsString('MonthlySoftwareFee', $content);
         $this->assertStringContainsString('seth@shipsaas.tech', $content);
         $this->assertStringContainsString('docking.shipsaas.tech', $content);
+    }
+
+    public function testRenderPdfUsingGotenbergMarkdownTemplate()
+    {
+        $markdownTemplate = DocumentTemplate::factory()->create([
+            'template' => file_get_contents(__DIR__ . '/__fixtures__/email.md'),
+            'default_variables' => [
+                'name' => 'Markdown Hehe',
+            ],
+        ]);
+
+        $response = $this->json('POST', 'api/v1/document-templates/' . $markdownTemplate->template->uuid . '/pdfs', [
+            'variables' => $markdownTemplate->template->default_variables,
+            'metadata' => [
+                'driver' => PdfService::GOTENBERG->value,
+                'templating' => TemplatingMode::MARKDOWN->value,
+            ],
+        ])->assertOk();
+
+        $url = $response->json('url');
+
+        $content = $this->readPdfToString(
+            public_path(
+                str_replace(
+                    'http://127.0.0.1:8000',
+                    '',
+                    $url
+                )
+            )
+        );
+
+        $this->assertStringContainsString('Markdown Hehe', $content);
     }
 
     private function readPdfToString(string $filePath): string

--- a/tests/Integration/__fixtures__/email.md
+++ b/tests/Integration/__fixtures__/email.md
@@ -1,0 +1,13 @@
+# Hello World
+
+Hello **{{ $name }}**
+
+## What do you do?
+
+@foreach (['php', 'pdf rendering', 'document template'] as $item)
+- {{ $item }}
+@endforeach
+
+### How are you?
+
+Super fine thanks

--- a/tests/Unit/Models/DocumentTemplateTest.php
+++ b/tests/Unit/Models/DocumentTemplateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use App\Enums\TemplatingMode;
 use App\Models\DocumentFile;
 use App\Models\DocumentTemplate;
 use Tests\TestCase;
@@ -25,31 +26,21 @@ class DocumentTemplateTest extends TestCase
         );
     }
 
-    public function testRenderHtmlOk()
+    public function testGetTemplatingModeReturnsTheModeFromMetadata()
     {
-        $template = DocumentTemplate::factory()->create([
-            'template' => 'Hello {{ $name }}',
-            'default_variables' => [
-                'name' => 'Seth',
+        $template = new DocumentTemplate([
+            'metadata' => [
+                'templating' => TemplatingMode::MARKDOWN->value,
             ],
         ]);
 
-        $renderedHtml = $template->renderHtml();
-
-        $this->assertSame('Hello Seth', $renderedHtml);
+        $this->assertSame(TemplatingMode::MARKDOWN, $template->getTemplatingMode());
     }
 
-    public function testRenderHtmlErrorReturnsPhpErrorString()
+    public function testGetTemplatingModeReturnsFallbackMode()
     {
-        $template = DocumentTemplate::factory()->create([
-            'template' => 'Hello {{ $name }}',
-            'default_variables' => [
-                'aaaa' => 'bbbb',
-            ],
-        ]);
+        $template = new DocumentTemplate();
 
-        $renderedHtml = $template->renderHtml();
-
-        $this->assertStringContainsString('Undefined variable $name', $renderedHtml);
+        $this->assertSame(TemplatingMode::BLADE, $template->getTemplatingMode());
     }
 }

--- a/tests/Unit/Services/TemplatingServices/BladeTemplatingServiceTest.php
+++ b/tests/Unit/Services/TemplatingServices/BladeTemplatingServiceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Services\TemplatingServices;
+
+use App\Models\DocumentTemplate;
+use App\Services\TemplatingServices\BladeTemplatingService;
+use Tests\TestCase;
+
+class BladeTemplatingServiceTest extends TestCase
+{
+    public function testRenderReturnsTheRenderedHtml()
+    {
+        $template = new DocumentTemplate([
+            'template' => 'Hello {{ $partner }}',
+        ]);
+
+        $service = new BladeTemplatingService();
+        $renderedHtml = $service->renderHtml($template, [
+            'partner' => 'Seth',
+        ]);
+
+        $this->assertSame('Hello Seth', $renderedHtml);
+    }
+
+    public function testRenderOnErrorReturnsTheErrorString()
+    {
+        $template = new DocumentTemplate([
+            'template' => 'Hello {{ $partner }}',
+        ]);
+
+        $service = new BladeTemplatingService();
+        $renderedHtml = $service->renderHtml($template, [
+            'name' => 'Seth',
+        ]);
+
+        $this->assertStringStartsWith('Failed to', $renderedHtml);
+    }
+}

--- a/tests/Unit/Services/TemplatingServices/MarkdownTemplatingServiceTest.php
+++ b/tests/Unit/Services/TemplatingServices/MarkdownTemplatingServiceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Services\TemplatingServices;
+
+use App\Models\DocumentTemplate;
+use App\Services\TemplatingServices\BladeTemplatingService;
+use App\Services\TemplatingServices\MarkdownTemplatingService;
+use Tests\TestCase;
+
+class MarkdownTemplatingServiceTest extends TestCase
+{
+    public function testRenderReturnsTheRenderedHtml()
+    {
+        $template = new DocumentTemplate([
+            'template' => file_get_contents(__DIR__ . '/../../../Integration/__fixtures__/email.md'),
+        ]);
+
+        $service = app(MarkdownTemplatingService::class);
+        $renderedHtml = $service->renderHtml($template, [
+            'name' => 'Seth',
+        ]);
+
+        $this->assertStringContainsString('Hello <strong>Seth</strong>', $renderedHtml);
+        $this->assertStringContainsString('<h1>', $renderedHtml);
+        $this->assertStringContainsString('<h2>', $renderedHtml);
+        $this->assertStringContainsString('<h3>', $renderedHtml);
+        $this->assertStringContainsString('<ul>', $renderedHtml);
+        $this->assertStringContainsString('</ul>', $renderedHtml);
+        $this->assertStringContainsString('<li>php', $renderedHtml);
+        $this->assertStringContainsString('<li>pdf rendering', $renderedHtml);
+        $this->assertStringContainsString('<li>document template', $renderedHtml);
+    }
+
+    public function testRenderOnErrorReturnsTheErrorString()
+    {
+        $template = new DocumentTemplate([
+            'template' => 'Hello {{ $partner }}',
+        ]);
+
+        $service = app(MarkdownTemplatingService::class);
+        $renderedHtml = $service->renderHtml($template, [
+            'name' => 'Seth',
+        ]);
+
+        $this->assertStringContainsString('Failed to', $renderedHtml);
+    }
+}


### PR DESCRIPTION
## Feature

This PR extracts the current Blade rendering to another layer and called it "Templating Services". Also introduces 
 the Markdown templating mode.

The biggest PRO is that we can add new templating on demand if we needed to (eg: volt from phalcon, mustache,...)

### Current Drivers
- Blade
- Markdown (utilizing Blade for dynamic rendering, then parsing markdown to HTML)

### Metadata

Introduces `templating` metadata property. 2 possible values: `blade` and `markdown`.

By default, `blade` will be used. 

### Breaking Changes

No