### PR TITLE
Improvement: Ability to use Document Template Key when invoking query/command

### DIFF
--- a/app/Models/DocumentTemplate.php
+++ b/app/Models/DocumentTemplate.php
@@ -48,4 +48,11 @@ class DocumentTemplate extends Model
 
         return TemplatingMode::from($rawMode);
     }
+
+    public static function getByUuidOrKey(string $value): DocumentTemplate
+    {
+        return DocumentTemplate::where(function ($q) use ($value) {
+            $q->orWhere('uuid', $value)->orWhere('key', $value);
+        })->firstOrFail();
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -44,14 +44,15 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting(): void
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(600)->by($request->user()?->id ?: $request->ip());
         });
     }
 
     private function registerModelBindings(): void
     {
         Route::model('documentFile', DocumentFile::class);
-        Route::model('documentTemplate', DocumentTemplate::class);
         Route::model('font', Font::class);
+
+        Route::bind('documentTemplateUuidKey', DocumentTemplate::getByUuidOrKey(...));
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,22 +18,28 @@ Route::prefix('v1')
         Route::get('access', [AuthController::class, 'access']);
 
         Route::resource('document-templates', DocumentTemplateController::class)
-            ->parameter('document-template', 'documentTemplate')
+            ->parameter('document-templates', 'documentTemplateUuidKey')
             ->except([
                 'create',
                 'edit',
             ]);
         Route::post(
-            'document-templates/{documentTemplate}/preview-html',
+            'document-templates/{documentTemplateUuidKey}/preview-html',
             [DocumentTemplateController::class, 'previewHtml']
         );
         Route::post(
-            'document-templates/{documentTemplate}/duplicate',
+            'document-templates/{documentTemplateUuidKey}/duplicate',
             [DocumentTemplateController::class, 'duplicate']
         );
 
-        Route::post('document-templates/{documentTemplate}/pdfs', [PdfRenderController::class, 'render']);
-        Route::post('document-templates/{documentTemplate}/pdfs-async', [PdfRenderController::class, 'renderAsync']);
+        Route::post(
+            'document-templates/{documentTemplateUuidKey}/pdfs',
+            [PdfRenderController::class, 'render']
+        );
+        Route::post(
+            'document-templates/{documentTemplateUuidKey}/pdfs-async',
+            [PdfRenderController::class, 'renderAsync']
+        );
 
         Route::get('document-files', [DocumentFileController::class, 'index']);
         Route::get('document-files/{documentFile}', [DocumentFileController::class, 'show']);


### PR DESCRIPTION
Before: we can only use the document template UUID in order to view/update/delete/render.

After: we can use `key` too, so it is matching with the initial documentation https://docking.shipsaas.tech/usage/maintain-ids-keys-from-services