### PR TITLE
Better logging & image improvement

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -48,6 +48,7 @@ ENV APP_ENV="production"
 ENV APP_KEY="base64:/UnGygYvVBmIh+VgNhMj6MyI/ieXTtzUJsUL4OUtZGI="
 ENV DB_CONNECTION="sqlite"
 ENV DATABASE_URL="sqlite:////var/www/html/docking.sqlite"
+ENV APP_URL="http://127.0.0.1:8000"
 
 ############# Storage ENV
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -21,11 +21,12 @@ RUN docker-php-ext-install pdo mbstring exif pcntl bcmath gd
 COPY . .
 COPY ./.docker/docking-worker.conf /etc/supervisor/conf.d/
 COPY ./.docker/docking-host.conf /etc/nginx/conf.d/default.conf
+COPY ./.docker/php-fpm.conf /usr/local/etc/php-fpm.d/
 
 RUN cp .docker/entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint
 
-# The bundle already built, no need to keep this to save size
+# The bundle already built (outer layer), no need to keep this to save size
 RUN rm -rf ./node_modules
 
 RUN php artisan optimize

--- a/.docker/docking-octane.conf
+++ b/.docker/docking-octane.conf
@@ -7,17 +7,17 @@ stopasgroup=true
 killasgroup=true
 numprocs=5
 redirect_stderr=true
-stdout_logfile=/var/log/docking-worker.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 
 [program:docking-octane]
 command=php /var/www/html/artisan octane:start --max-requests=500
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/supervisor/%(program_name)s_stderr.log
-stdout_logfile_maxbytes=10MB
-stdout_logfile=/var/log/supervisor/%(program_name)s_stdout.log
-stderr_logfile_maxbytes=10MB
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
 
 [program:docking-nginx]
@@ -27,8 +27,7 @@ autorestart=true
 startretries=5
 numprocs=1
 startsecs=0
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
-stderr_logfile=/var/log/supervisor/%(program_name)s_stderr.log
-stderr_logfile_maxbytes=10MB
-stdout_logfile=/var/log/supervisor/%(program_name)s_stdout.log
-stdout_logfile_maxbytes=10MB

--- a/.docker/docking-octane.conf
+++ b/.docker/docking-octane.conf
@@ -12,7 +12,7 @@ stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 
 [program:docking-octane]
-command=php /var/www/html/artisan octane:start --max-requests=500
+command=php /var/www/html/artisan octane:start --max-requests=500 --log-level=debug
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/.docker/docking-octane.conf
+++ b/.docker/docking-octane.conf
@@ -7,7 +7,7 @@ stopasgroup=true
 killasgroup=true
 numprocs=5
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 
@@ -16,7 +16,7 @@ command=php /var/www/html/artisan octane:start --max-requests=500
 autostart=true
 autorestart=true
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
 
@@ -28,6 +28,6 @@ startretries=5
 numprocs=1
 startsecs=0
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d

--- a/.docker/docking-worker.conf
+++ b/.docker/docking-worker.conf
@@ -7,17 +7,16 @@ stopasgroup=true
 killasgroup=true
 numprocs=5
 redirect_stderr=true
-stdout_logfile=/var/log/docking-worker.log
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 
 [program:docking-php-fpm]
 command=php-fpm -F -R
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/supervisor/%(program_name)s_stderr.log
-stdout_logfile_maxbytes=10MB
-stdout_logfile=/var/log/supervisor/%(program_name)s_stdout.log
-stderr_logfile_maxbytes=10MB
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
 
 [program:docking-nginx]
@@ -27,8 +26,6 @@ autorestart=true
 startretries=5
 numprocs=1
 startsecs=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
-stderr_logfile=/var/log/supervisor/%(program_name)s_stderr.log
-stderr_logfile_maxbytes=10MB
-stdout_logfile=/var/log/supervisor/%(program_name)s_stdout.log
-stdout_logfile_maxbytes=10MB

--- a/.docker/docking-worker.conf
+++ b/.docker/docking-worker.conf
@@ -7,7 +7,7 @@ stopasgroup=true
 killasgroup=true
 numprocs=5
 redirect_stderr=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 stopwaitsecs=3600
 
@@ -15,7 +15,7 @@ stopwaitsecs=3600
 command=php-fpm -F -R
 autostart=true
 autorestart=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d
 
@@ -26,6 +26,6 @@ autorestart=true
 startretries=5
 numprocs=1
 startsecs=0
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/1/fd/1
 stdout_logfile_maxbytes=0
 process_name=%(program_name)s_%(process_num)02d

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -16,8 +16,10 @@ for f in /var/www/html/.docker/scripts/*.sh; do
     bash "$f" || break
 done
 
-echo "For SQLite users, please note down the UID & GID, then run CHOWN on the host machine"
-id www-data
+if [ "$DB_CONNECTION" = "sqlite" ]; then
+    echo "For SQLite users, please note down the UID & GID, then run CHOWN on the host machine"
+    id www-data
+fi
 
 echo "Starting the application using supervisor...";
 exec /usr/bin/supervisord --nodaemon

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env sh
 set -e
 
+echo "
+ ____             _  ___
+|  _ \  ___   ___| |/ (_)_ __   __ _
+| | | |/ _ \ / __| ' /| | '_ \ / _  |
+| |_| | (_) | (__| . \| | | | | (_| |
+|____/ \___/ \___|_|\_\_|_| |_|\__, |
+                               |___/
+";
+
 # Run user scripts, if they exist
 for f in /var/www/html/.docker/scripts/*.sh; do
     # Bail out this loop if any script exits with non-zero status code
     bash "$f" || break
 done
 
-echo "Welcome to DocKing";
+echo "For SQLite users, please note down the UID & GID, then run CHOWN on the host machine"
+id www-data
+
 echo "Starting the application using supervisor...";
 exec /usr/bin/supervisord --nodaemon

--- a/.docker/octane.Dockerfile
+++ b/.docker/octane.Dockerfile
@@ -1,7 +1,4 @@
-FROM ghcr.io/roadrunner-server/roadrunner:latest AS roadrunner
-FROM php:8.2-fpm
-
-COPY --from=roadrunner /usr/bin/rr /usr/local/bin/rr
+FROM php:8.2-cli
 
 WORKDIR /var/www/html
 
@@ -33,6 +30,9 @@ RUN rm -rf ./node_modules
 
 RUN php artisan optimize
 RUN php artisan storage:link
+RUN ./vendor/bin/rr get-binary
+RUN chmod +x ./rr
+
 
 RUN chown -R www-data:www-data storage
 RUN chown -R www-data:www-data storage/app
@@ -44,7 +44,7 @@ RUN chown www-data:www-data docking.sqlite
 # Nginx remove default site
 RUN rm /etc/nginx/sites-enabled/default
 
-EXPOSE 80
+EXPOSE 80 8080
 
 ############# Default app ENV
 ENV APP_ENV="production"

--- a/.docker/php-fpm.conf
+++ b/.docker/php-fpm.conf
@@ -1,0 +1,3 @@
+[global]
+error_log = /proc/1/fd/1
+

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bc61918922aa29800a2e5e5c081f041",
+    "content-hash": "17523e037e289791fbefe4fd53b4507f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1494,20 +1494,20 @@
         },
         {
             "name": "laravel/octane",
-            "version": "v2.0.5",
+            "version": "v2.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/octane.git",
-                "reference": "f42d7f1814dda993a204e6bf8fe31092f1cfc9e6"
+                "reference": "9f36957a2166ba13fd9787246fbba061f307a3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/octane/zipball/f42d7f1814dda993a204e6bf8fe31092f1cfc9e6",
-                "reference": "f42d7f1814dda993a204e6bf8fe31092f1cfc9e6",
+                "url": "https://api.github.com/repos/laravel/octane/zipball/9f36957a2166ba13fd9787246fbba061f307a3f6",
+                "reference": "9f36957a2166ba13fd9787246fbba061f307a3f6",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-diactoros": "^3.0.0",
+                "laminas/laminas-diactoros": "^3.0",
                 "laravel/framework": "^10.10.1",
                 "laravel/serializable-closure": "^1.3.0",
                 "nesbot/carbon": "^2.66.0",
@@ -1568,6 +1568,7 @@
             ],
             "description": "Supercharge your Laravel application's performance.",
             "keywords": [
+                "frankenphp",
                 "laravel",
                 "octane",
                 "roadrunner",
@@ -1577,7 +1578,7 @@
                 "issues": "https://github.com/laravel/octane/issues",
                 "source": "https://github.com/laravel/octane"
             },
-            "time": "2023-08-08T15:12:51+00:00"
+            "time": "2024-01-08T14:58:30+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -10372,5 +10373,5 @@
         "php": "^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -54,7 +54,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['stderr'],
             'ignore_exceptions' => false,
         ],
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,18 +4,21 @@ services:
   docking:
     build:
       context: .
-      dockerfile: .docker/Dockerfile
+      dockerfile: .docker/octane.Dockerfile
     volumes:
+      - ./seth.sqlite:/var/www/html/database/seth.sqlite
       - app_storage:/var/www/html/storage/app
-    links:
-      - gotenberg
+    environment:
+      DATABASE_URL: 'sqlite:////var/www/html/database/seth.sqlite'
+    # links:
+    #   - gotenberg
     ports:
       - '8888:80'
 
-  gotenberg:
-    image: gotenberg/gotenberg:7
-    ports:
-      - '9898:3000'
+  # gotenberg:
+  #   image: gotenberg/gotenberg:7
+  #   ports:
+  #     - '9898:3000'
 
 volumes:
   app_storage:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,19 +6,20 @@ services:
       context: .
       dockerfile: .docker/octane.Dockerfile
     volumes:
-      - ./seth.sqlite:/var/www/html/database/seth.sqlite
+      - ./docking.sqlite:/var/www/html/database/docking.sqlite
       - app_storage:/var/www/html/storage/app
     environment:
-      DATABASE_URL: 'sqlite:////var/www/html/database/seth.sqlite'
-    # links:
-    #   - gotenberg
+      DATABASE_URL: 'sqlite:////var/www/html/database/docking.sqlite'
+    links:
+      - gotenberg
     ports:
       - '8888:80'
+      - '8080:8080'
 
-  # gotenberg:
-  #   image: gotenberg/gotenberg:7
-  #   ports:
-  #     - '9898:3000'
+  gotenberg:
+    image: gotenberg/gotenberg:7
+    ports:
+      - '9898:3000'
 
 volumes:
   app_storage:

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', function () {
+    \Illuminate\Support\Facades\Log::error('test');
     return view('welcome');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', function () {
-    \Illuminate\Support\Facades\Log::error('test');
     return view('welcome');
 });
 


### PR DESCRIPTION
Closes #30 

- Write logs to stdout, so that we can use "docker logs".
- (For SQLite users only) When running, DocKing will echo the UID & GID of `www-data` so that userland can do `chown UID:GID` on host
